### PR TITLE
Fixed didCrashDuringPreviousExecution on Android

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/firebasecrashlytics/FirebaseCrashlytics.java
+++ b/android/src/main/java/com/getcapacitor/community/firebasecrashlytics/FirebaseCrashlytics.java
@@ -183,7 +183,7 @@ public class FirebaseCrashlytics extends Plugin {
    * @return crashed: boolean true/false
    */
   @PluginMethod
-  public void didCrashOnPreviousExecution(PluginCall call) {
+  public void didCrashDuringPreviousExecution(PluginCall call) {
     call.success(
       new JSObject()
       .put(


### PR DESCRIPTION
Function "didCrashDuringPreviousExecution" on Android was wrongly named "didCrashOnPreviousExecution" resulting in a 

`TypeError: FirebaseCrashlytics.didCrashDuringPreviousExecution is not a function`

error