### PR TITLE
FirebaseApp.configure() not called when FirebaseApp.allApps?.count == nil

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -7,7 +7,7 @@ import FirebaseCrashlytics
 public class FirebaseCrashlytics: CAPPlugin {
     
     public override func load() {
-        if (FirebaseApp.allApps?.count == 0) {
+        if (FirebaseApp.allApps?.count == 0 || FirebaseApp.allApps?.count == nil) {
             FirebaseApp.configure()
         }
     }


### PR DESCRIPTION
`FirebaseApp.configure()` is not called when `FirebaseApp.allApps?.count` returns `nil` instead of `0`.
```
(lldb) po FirebaseApp.allApps?.count
nil
```

This led to the following message in the console
```
The default Firebase app has not yet been configured. Add `[FIRApp configure];` (`FirebaseApp.configure()` in Swift) to your application initialization. Read more: https://goo.gl/ctyzm8.
```

Maybe this is the source of #2 