### PR TITLE
fix: remove constraint for Firebase/Crashlytics iOS SDK dependency.

### DIFF
--- a/CapacitorCommunityFirebaseCrashlytics.podspec
+++ b/CapacitorCommunityFirebaseCrashlytics.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target  = '13.0'
   s.dependency 'Capacitor'
-  s.dependency 'Firebase/Crashlytics', '8.12.1'
+  s.dependency 'Firebase/Crashlytics', '>= 8.12.1'
   s.swift_version = '5.1'
   s.static_framework = true
 end

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -9,7 +9,7 @@ end
 
 target 'Plugin' do
   capacitor_pods
-  pod 'Firebase/Crashlytics', '8.12.1'
+  pod 'Firebase/Crashlytics', '>= 8.12.1'
 end
 
 target 'PluginTests' do


### PR DESCRIPTION
Using Capacitor 5, we can using another dependency for Firebase/Crashlytics.

This plugin requires you to use iOS Firebase/Crashlytics 8.12.1.

This PR allow to use Firebase/Crashlytics >= 8.12.1 for iOS and avoid to get this error: 

> [!] CocoaPods could not find compatible versions for pod "Firebase/Crashlytics":
>         In snapshot (Podfile.lock):
>         Firebase/Crashlytics (= 9.3.0)

> In Podfile:
>         CapacitorCommunityFirebaseCrashlytics (from `../../node_modules/@capacitor-community/firebase-crashlytics`) was
>         resolved to 3.0.0, which depends on
>         Firebase/Crashlytics (= 8.12.1)